### PR TITLE
Fix maximum description length in embed.rs

### DIFF
--- a/src/model/channel/embed.rs
+++ b/src/model/channel/embed.rs
@@ -9,7 +9,7 @@ use crate::model::{Colour, Timestamp};
 /// You can include an attachment in your own message by a user or a bot, or in a webhook.
 ///
 /// **Note**: Maximum amount of characters you can put is 256 in a field name,
-/// 1024 in a field value, and 2048 in a description.
+/// 1024 in a field value, and 4096 in a description.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object).
 ///


### PR DESCRIPTION
This PR updates the maximum description length in the embed.rs file from 2048 to 4096 characters to align with the Discord documentation.

This only changes the docs.